### PR TITLE
Document how to make packages externally referenceable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,26 @@ pytests will run with pre-commit, to run manually use:
 ```sh
 pixi run tests
 ```
+
+## Enabling packages to be externally referenced
+
+If you need to be able to use your packages as dependencies from another
+project, you must add `project.dependencies` to each package. For this example
+monorepo, you would add to both `packages/pixi_py/pyproject.toml` and
+`packages/pixi_py_copy/pyproject.toml`:
+
+```toml
+[project]
+...
+dependencies = ["rich"]
+```
+
+Then you can reference your packages from outside of this repo as:
+
+```toml
+pixi_py = { git = "…", subdirectory = "packages/pixi_py", branch = "main" }
+pixi_py_copy = { git = "…", subdirectory = "packages/pixi_py_copy", branch = "main" }
+```
+
+The downside of this strategy is the duplication of the dependency list; now
+your package `pyproject.toml`s can get out of sync with the top-level config.


### PR DESCRIPTION
Add rich dependency at the sub-package level. This allows for referencing a specific sub-package from outside of this repo via `pixi_py = { git = "…", subdirectory = "packages/pixi_py", branch = "main" }`. This is ability is critical to my use case.

It has the downside of duplicating the dependency list from the top-level `pixi.toml`, but at least not duplicating the version constraints. For me, this is a worthwhile trade-off.

Regardless of whether you accept this PR, thanks for posting this example repo. It helped me a lot.